### PR TITLE
fix return values

### DIFF
--- a/src/localnameservicecache.cpp
+++ b/src/localnameservicecache.cpp
@@ -137,8 +137,6 @@ bool LocalNameServiceEditor::save(const ContactMethod* number)
             }
 
             file.close();
-
-            return false;
         }
         else
             qWarning() << "Unable to save the registered names";

--- a/src/profilemodel.cpp
+++ b/src/profilemodel.cpp
@@ -616,6 +616,7 @@ bool ProfileModel::setProfile(Account* a, Person* p)
     a->contactMethod()->setPerson(p);
 
     d_ptr->setProfile(accNode, proNode);
+    return true;
 }
 
 void ProfileModelPrivate::setProfile(ProfileNode* accNode, ProfileNode* proNode)


### PR DESCRIPTION
profilemodel: add missing return to a non-void function - without the return statement gcc 8.0 on Fedora 28 generates a code which never returns, it jumps back and forth inside the function eventually causing a double free of a local variable.

localnameservicecache: don't return a value from a lambda - this is harmless but with the return statement in place the lambda is treated as returning a value, resulting in a warning about control reaching the end of the function without returning a value. When the return statement is removed the lambda is considered not to return anything, so no warning is produced.