### PR TITLE
individual: Prevent double free and circular reference

### DIFF
--- a/src/individual.cpp
+++ b/src/individual.cpp
@@ -74,7 +74,7 @@ public:
 
     QSharedPointer<EventAggregate> m_pEventAggregate;
 
-    QSharedPointer<Individual> m_pWeakRef {nullptr};
+    QWeakPointer<Individual> m_pWeakRef {nullptr};
 
     // Helpers
     void connectContactMethod(ContactMethod* cm);
@@ -1143,7 +1143,7 @@ bool Individual::hasBookmarks() const
 
 QSharedPointer<Individual> Individual::getIndividual(Individual* cm)
 {
-    return cm ? cm->d_ptr->m_pWeakRef : nullptr;
+    return cm ? cm->d_ptr->m_pWeakRef.toStrongRef() : nullptr;
 }
 
 Person* Individual::buildPerson() const

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -210,6 +210,8 @@ Person::~Person()
 
    if (d_ptr->m_lParents.isEmpty()) {
       d_ptr->setParent(nullptr);
+      if (d_ptr->m_pIndividual)
+         d_ptr->m_pIndividual->setParent(nullptr);
       delete d_ptr;
    }
 }


### PR DESCRIPTION
Without this patch there is a double ownership of an `Individual` in a `Person`/`PersonPrivate`:
- first through the [`m_pIndividual`](https://github.com/Elv13/libringqt/blob/2b7db826fab6a51fa0414fa08de23db5322ecdc6/src/private/person_p.h#L56) field of the `PersonPrivate`
- second through the parent/children relationship of `QObject` established in [`Individual::Individual(Person* parent)`](https://github.com/Elv13/libringqt/blob/2b7db826fab6a51fa0414fa08de23db5322ecdc6/src/individual.cpp#L113)

This double ownership causes a double free during destruction of the owning `Person` instance.

While at it I've also changed the [`m_pWeakRef`](https://github.com/Elv13/libringqt/blob/2b7db826fab6a51fa0414fa08de23db5322ecdc6/src/individual.cpp#L77) in `IndividualPrivate` to `QWeakPointer`, as without this change the reference count never reaches zero, so the `Individual` is never deleted.